### PR TITLE
Help to transition of SubstitutionSystems for UniMath PR 1644

### DIFF
--- a/UniMath/Bicategories/MonoidalCategories/WhiskeredMonoidalFromBicategory.v
+++ b/UniMath/Bicategories/MonoidalCategories/WhiskeredMonoidalFromBicategory.v
@@ -86,7 +86,7 @@ Definition tensor_from_bicat_and_ob
 Definition monoidal_data_from_bicat_and_ob: monoidal_data category_from_bicat_and_ob.
 Proof.
   use make_monoidal_data.
-  - exact tensor_from_bicat_and_ob.
+  - exact tensor_data_from_bicat_and_ob.
   - exact (id₁ c0).
   - red; intros; apply lunitor.
   - red; intros; apply linvunitor.

--- a/UniMath/CategoryTheory/.package/files
+++ b/UniMath/CategoryTheory/.package/files
@@ -264,11 +264,14 @@ Monoidal/Displayed/DisplayedMonoidal.v
 Monoidal/Displayed/TotalDisplayedMonoidal.v
 Monoidal/Displayed/MonoidalSections.v
 
+Monoidal/Examples/EndofunctorsMonoidalElementary.v
+Monoidal/Examples/MonadsAsMonoidsElementary.v
 Monoidal/Examples/CartesianMonoidal.v
 Monoidal/Examples/DisplayedCartesianMonoidal.v
 Monoidal/Examples/MonoidalPointedObjects.v
 Monoidal/Examples/EndofunctorsMonoidal.v
 Monoidal/Examples/MonoidalDialgebras.v
+
 
 Monoidal/AlternativeDefinitions/MonoidalCategoriesReordered.v
 Monoidal/AlternativeDefinitions/MonoidalCategoriesTensored.v
@@ -289,8 +292,8 @@ Actegories/MorphismsOfActegories.v
 Actegories/ProductActegory.v
 Actegories/ProductsInActegories.v
 Actegories/CoproductsInActegories.v
-Actegories/Examples/ActionOfEndomorphismsInCATWhiskeredElementary.v
-Actegories/Examples/SelfActionInCATWhiskeredElementary.v
+Actegories/Examples/ActionOfEndomorphismsInCATElementary.v
+Actegories/Examples/SelfActionInCATElementary.v
 Actegories/ConstructionOfActegoryMorphisms.v
 
 MonoidalOld/WhiskeredBifunctors.v
@@ -298,7 +301,6 @@ MonoidalOld/MonoidalCategoriesWhiskered.v
 MonoidalOld/Actegories.v
 MonoidalOld/CartesianMonoidalCategoriesWhiskered.v
 MonoidalOld/MonoidalFunctorsWhiskered.v
-MonoidalOld/Examples/EndofunctorsWhiskeredMonoidalElementary.v
 MonoidalOld/WhiskeredDisplayedBifunctors.v
 MonoidalOld/DisplayedMonoidalWhiskered.v
 MonoidalOld/DisplayedCartesianMonoidalCategoriesWhiskered.v
@@ -309,7 +311,6 @@ MonoidalOld/ProductActegory.v
 MonoidalOld/ProductsInActegories.v
 MonoidalOld/CoproductsInActegories.v
 MonoidalOld/Examples/ActionOfEndomorphismsInCATWhiskeredElementary.v
-MonoidalOld/Examples/SelfActionInCATWhiskeredElementary.v
 MonoidalOld/ConstructionOfActegoryMorphisms.v
 MonoidalOld/ActionBasedStrongMonads.v
 MonoidalOld/MonoidalSectionsWhiskered.v
@@ -318,7 +319,6 @@ MonoidalOld/ClosedMonoidalCategoriesWhiskered.v
 MonoidalOld/MonoidalCategoriesReordered.v
 MonoidalOld/MonoidalDialgebras.v
 MonoidalOld/CategoriesOfMonoidsWhiskered.v
-MonoidalOld/Examples/MonadsAsMonoidsWhiskeredElementary.v
 
 DisplayedCats/MoreFibrations/Prefibrations.v
 DisplayedCats/MoreFibrations/CartesiannessOfComposites.v

--- a/UniMath/CategoryTheory/Actegories/Actegories.v
+++ b/UniMath/CategoryTheory/Actegories/Actegories.v
@@ -31,35 +31,35 @@ Section A.
 Context {V : category} (Mon_V : monoidal V). (** given the monoidal category that acts upon categories *)
 
 (** Data **)
-Definition action (C : category) : UU :=
-  bifunctor V C C.
-Identity Coercion actionintobifunctor : action >-> bifunctor.
+Definition action_data (C : category) : UU :=
+  bifunctor_data V C C.
+Identity Coercion actionintobifunctor : action_data >-> bifunctor_data.
 
 (** the following widens the concept of left unitor of a monoidal category, a right unitor is not appropriate for actions *)
-Definition action_unitor_data {C : category} (A : action C) : UU :=
+Definition action_unitor_data {C : category} (A : action_data C) : UU :=
   ∏ (x : C), C⟦I_{Mon_V} ⊗_{A} x, x⟧.
 
-Definition action_unitorinv_data {C : category} (A : action C) : UU :=
+Definition action_unitorinv_data {C : category} (A : action_data C) : UU :=
   ∏ (x : C), C⟦x, I_{Mon_V} ⊗_{A} x⟧.
 
-Definition actor_data {C : category} (A : action C) : UU :=
+Definition actor_data {C : category} (A : action_data C) : UU :=
   ∏ (v w : V) (x : C), C ⟦(v ⊗_{Mon_V} w) ⊗_{A} x, v ⊗_{A} (w ⊗_{A} x)⟧.
 
-Definition actorinv_data {C : category} (A : action C) : UU :=
+Definition actorinv_data {C : category} (A : action_data C) : UU :=
   ∏ (v w : V) (x : C), C ⟦v ⊗_{A} (w ⊗_{A} x), (v ⊗_{Mon_V} w) ⊗_{A} x⟧.
 
 Definition actegory_data (C : category) : UU :=
-    ∑ A : action C,
+    ∑ A : action_data C,
         (action_unitor_data A) × (action_unitorinv_data A) ×
            (actor_data A) × (actorinv_data A).
 
-Definition make_actegory_data {C : category} {A : action C}
+Definition make_actegory_data {C : category} {A : action_data C}
   (au : action_unitor_data A) (auinv : action_unitorinv_data A)
   (aα : actor_data A) (aαinv : actorinv_data A) : actegory_data C
   := (A,,au,,auinv,,aα,,aαinv).
 
-Definition actegory_action {C : category} (AD : actegory_data C) : action C := pr1 AD.
-Coercion actegory_action : actegory_data >-> action.
+Definition actegory_action_data {C : category} (AD : actegory_data C) : action_data C := pr1 AD.
+Coercion actegory_action_data : actegory_data >-> action_data.
 
 Definition actegory_unitordata {C : category} (AD : actegory_data C) : action_unitor_data AD
   := pr1 (pr2 AD).
@@ -79,111 +79,72 @@ Notation "aαinv_{ AD }" := (actegory_actorinvdata AD).
 
 
 (** Axioms **)
-Definition action_unitor_nat {C : category} {A : action C} (au : action_unitor_data A) : UU :=
+Definition action_unitor_nat {C : category} {A : action_data C} (au : action_unitor_data A) : UU :=
   ∏ (x y : C), ∏ (f : C ⟦x,y⟧),  I_{Mon_V} ⊗^{A}_{l} f · au y = au x · f.
 
-Definition action_unitorinv_nat {C : category} {A : action C} (auinv : action_unitorinv_data A) : UU :=
+Definition action_unitorinv_nat {C : category} {A : action_data C} (auinv : action_unitorinv_data A) : UU :=
   ∏ (x y : C), ∏ (f : C ⟦x,y⟧),  auinv x · I_{Mon_V} ⊗^{A}_{l} f = f · auinv y.
 
-Definition action_unitor_iso_law {C : category} {A : action C} (au : action_unitor_data A) (auinv : action_unitorinv_data A) : UU :=
+Definition action_unitor_iso_law {C : category} {A : action_data C} (au : action_unitor_data A) (auinv : action_unitorinv_data A) : UU :=
   ∏ (x : C), is_inverse_in_precat (au x) (auinv x).
 
-Definition action_unitor_law {C : category} {A : action C} (au : action_unitor_data A) (auinv : action_unitorinv_data A) : UU :=
+Definition action_unitor_law {C : category} {A : action_data C} (au : action_unitor_data A) (auinv : action_unitorinv_data A) : UU :=
   action_unitor_nat au × action_unitor_iso_law au auinv.
 
-Definition action_unitorlaw_nat {C : category} {A : action C} {au : action_unitor_data A} {auinv : action_unitorinv_data A}
+Definition action_unitorlaw_nat {C : category} {A : action_data C} {au : action_unitor_data A} {auinv : action_unitorinv_data A}
   (aul : action_unitor_law au auinv) : action_unitor_nat au := pr1 aul.
 
-Definition action_unitorlaw_iso_law {C : category} {A : action C} {au : action_unitor_data A} {auinv : action_unitorinv_data A}
+Definition action_unitorlaw_iso_law {C : category} {A : action_data C} {au : action_unitor_data A} {auinv : action_unitorinv_data A}
   (aul : action_unitor_law au auinv) : action_unitor_iso_law au auinv := pr2 aul.
 
-Definition actor_nat_leftwhisker {C : category} {A : action C} (aα : actor_data A) : UU
+Definition actor_nat_leftwhisker {C : category} {A : action_data C} (aα : actor_data A) : UU
   := ∏ (v w : V) (z z' : C) (h : C⟦z,z'⟧),
     (aα v w z) · (v ⊗^{A}_{l} (w ⊗^{A}_{l} h)) = ((v ⊗_{Mon_V} w) ⊗^{A}_{l} h) · (aα v w z').
 
-Definition actor_nat_rightwhisker {C : category} {A : action C} (aα : actor_data A) : UU
+Definition actor_nat_rightwhisker {C : category} {A : action_data C} (aα : actor_data A) : UU
   := ∏ (v v' w : V) (z : C) (f : V⟦v,v'⟧),
     (aα v w z) · (f ⊗^{A}_{r} (w ⊗_{A} z)) = ((f ⊗^{Mon_V}_{r} w) ⊗^{A}_{r} z) · (aα v' w z).
 
-Definition actor_nat_leftrightwhisker {C : category} {A : action C} (aα : actor_data A) : UU
+Definition actor_nat_leftrightwhisker {C : category} {A : action_data C} (aα : actor_data A) : UU
   := ∏ (v w w' : V) (z : C) (g : V⟦w,w'⟧),
     (aα v w z) · (v ⊗^{A}_{l} (g ⊗^{A}_{r} z)) = ((v ⊗^{Mon_V}_{l} g) ⊗^{A}_{r} z) · (aα v w' z).
 
-Lemma actor_nat1 {C : category} {A : action C} {aα : actor_data A} (aαnl : actor_nat_leftwhisker aα)
-  (aαnr : actor_nat_rightwhisker aα) (aαnlr : actor_nat_leftrightwhisker aα)
-  {v v' w w' : V} {z z' : C} (f : V⟦v,v'⟧) (g : V⟦w,w'⟧) (h : C⟦z,z'⟧) :
-  (aα v w z) · ((f ⊗^{A}_{r} (w ⊗_{A} z)) · (v' ⊗^{A}_{l} ((g ⊗^{A}_{r} z) · (w' ⊗^{A}_{l} h)))) =
-    (((f ⊗^{Mon_V}_{r} w) · (v' ⊗^{Mon_V}_{l} g))  ⊗^{A}_{r} z) · ((v' ⊗_{Mon_V} w') ⊗^{A}_{l} h) · (aα v' w' z').
-Proof.
-  rewrite assoc.
-  rewrite aαnr.
-  rewrite assoc'.
-  etrans. {
-    apply cancel_precomposition.
-    rewrite (bifunctor_leftcomp A).
-    rewrite assoc.
-    rewrite aαnlr.
-    apply idpath.
-  }
 
-  etrans. {
-    apply cancel_precomposition.
-    rewrite assoc'.
-    apply cancel_precomposition.
-    apply aαnl.
-  }
-  rewrite assoc.
-  rewrite assoc.
-  apply cancel_postcomposition.
-  apply pathsinv0.
-  rewrite (bifunctor_rightcomp A).
-  apply idpath.
-Qed.
-
-Lemma actor_nat2 {C : category} {A : action C} {aα : actor_data A} (aαnl : actor_nat_leftwhisker aα)
-  (aαnr : actor_nat_rightwhisker aα) (aαnlr : actor_nat_leftrightwhisker aα)
-  {v v' w w' : V} {z z' : C} (f : V⟦v,v'⟧) (g : V⟦w,w'⟧) (h : C⟦z,z'⟧) :
-  (aα v w z) · (f ⊗^{A} (g ⊗^{A} h)) = ((f ⊗^{Mon_V} g) ⊗^{A} h) · (aα v' w' z').
-Proof.
-  intros.
-  unfold functoronmorphisms1.
-  exact (actor_nat1 aαnl aαnr aαnlr f g h).
-Qed.
-
-Definition actor_iso_law {C : category} {A : action C} (aα : actor_data A) (aαinv : actorinv_data A) : UU
+Definition actor_iso_law {C : category} {A : action_data C} (aα : actor_data A) (aαinv : actorinv_data A) : UU
   := ∏ (v w : V) (z : C), is_inverse_in_precat (aα v w z) (aαinv v w z).
 
-Definition actor_law {C : category} {A : action C} (aα : actor_data A) (aαinv : actorinv_data A) : UU :=
+Definition actor_law {C : category} {A : action_data C} (aα : actor_data A) (aαinv : actorinv_data A) : UU :=
   (actor_nat_leftwhisker aα) × (actor_nat_rightwhisker aα) ×
     (actor_nat_leftrightwhisker aα) × (actor_iso_law aα aαinv).
 
-Definition actorlaw_natleft {C : category} {A : action C} {aα : actor_data A} {aαinv : actorinv_data A}
+Definition actorlaw_natleft {C : category} {A : action_data C} {aα : actor_data A} {aαinv : actorinv_data A}
   (aαl : actor_law aα aαinv) : actor_nat_leftwhisker aα := pr1 aαl.
-Definition actorlaw_natright {C : category} {A : action C} {aα : actor_data A} {aαinv : actorinv_data A}
+Definition actorlaw_natright {C : category} {A : action_data C} {aα : actor_data A} {aαinv : actorinv_data A}
   (aαl : actor_law aα aαinv) : actor_nat_rightwhisker aα := pr1 (pr2 aαl).
-Definition actorlaw_natleftright {C : category} {A : action C} {aα : actor_data A} {aαinv : actorinv_data A}
+Definition actorlaw_natleftright {C : category} {A : action_data C} {aα : actor_data A} {aαinv : actorinv_data A}
   (aαl : actor_law aα aαinv) : actor_nat_leftrightwhisker aα := pr1 (pr2 (pr2 aαl)).
-Definition actorlaw_iso_law {C : category} {A : action C} {aα : actor_data A} {aαinv : actorinv_data A}
+Definition actorlaw_iso_law {C : category} {A : action_data C} {aα : actor_data A} {aαinv : actorinv_data A}
   (aαl : actor_law aα aαinv) : actor_iso_law aα aαinv := pr2 (pr2 (pr2 aαl)).
 
 Definition actegory_triangle_identity {C : category}
-           {A : action C}
+           {A : action_data C}
            (au : action_unitor_data A)
            (aα : actor_data A)
   := ∏ (v : V) (y : C), (aα v I_{Mon_V} y) · (v ⊗^{A}_{l} (au y)) = (ru_{Mon_V} v) ⊗^{A}_{r} y.
 
 Definition actegory_triangle_identity' {C : category}
-           {A : action C}
+           {A : action_data C}
            (au : action_unitor_data A)
            (aα : actor_data A)
     := ∏ (v : V) (y : C), (aα I_{Mon_V} v y) · (au (v ⊗_{A} y)) = (lu_{Mon_V} v) ⊗^{A}_{r} y.
 
-Definition actegory_pentagon_identity {C : category} {A : action C} (aα : actor_data A) : UU :=
+Definition actegory_pentagon_identity {C : category} {A : action_data C} (aα : actor_data A) : UU :=
   ∏ (w v v' : V) (z : C),
     ((α_{Mon_V} w v v') ⊗^{A}_{r} z) · (aα w (v ⊗_{Mon_V} v') z) · (w ⊗^{A}_{l} (aα v v' z)) =
       (aα (w⊗_{Mon_V} v) v' z) · (aα w v (v' ⊗_{A} z)).
 
 Definition actegory_laws {C : category} (AD : actegory_data C) : UU :=
+  is_bifunctor AD ×
   (action_unitor_law au_{AD} auinv_{AD}) × (actor_law aα_{AD} aαinv_{AD}) ×
     (actegory_triangle_identity au_{AD} aα_{AD}) × (actegory_pentagon_identity aα_{AD}).
 
@@ -195,7 +156,16 @@ Coercion actegory_actdata : actegory >-> actegory_data.
 
 Definition actegory_actlaws {C : category} (Act : actegory C) : actegory_laws Act := pr2 Act.
 
-Definition actegory_unitorlaw {C : category} (Act : actegory C) : action_unitor_law au_{Act} auinv_{Act} := pr1 (actegory_actlaws Act).
+Definition actegory_action_is_bifunctor {C : category} (Act : actegory C) : is_bifunctor Act
+  := pr12 Act.
+
+Coercion actegory_action
+         {C : category}
+         (Act : actegory C)
+  : bifunctor V C C
+  := _ ,, actegory_action_is_bifunctor Act.
+
+Definition actegory_unitorlaw {C : category} (Act : actegory C) : action_unitor_law au_{Act} auinv_{Act} := pr12 (actegory_actlaws Act).
 Definition actegory_unitornat {C : category} (Act : actegory C) : action_unitor_nat au_{Act} := action_unitorlaw_nat (actegory_unitorlaw Act).
 Definition actegory_unitorisolaw {C : category} (Act : actegory C) : action_unitor_iso_law au_{Act} auinv_{Act} := action_unitorlaw_iso_law (actegory_unitorlaw Act).
 
@@ -209,14 +179,54 @@ Proof.
   apply pathsinv0, actegory_unitornat.
 Qed.
 
-Definition actegory_actorlaw {C : category} (Act : actegory C) : actor_law aα_{Act} aαinv_{Act} := pr12 (actegory_actlaws Act).
+Definition actegory_actorlaw {C : category} (Act : actegory C) : actor_law aα_{Act} aαinv_{Act} := pr122 (actegory_actlaws Act).
 Definition actegory_actornatleft {C : category} (Act : actegory C) : actor_nat_leftwhisker aα_{Act} := actorlaw_natleft (actegory_actorlaw Act).
 Definition actegory_actornatright {C : category} (Act : actegory C) : actor_nat_rightwhisker aα_{Act} := actorlaw_natright (actegory_actorlaw Act).
 Definition actegory_actornatleftright {C : category} (Act : actegory C) : actor_nat_leftrightwhisker aα_{Act} := actorlaw_natleftright (actegory_actorlaw Act).
 Definition actegory_actorisolaw {C : category} (Act : actegory C) : actor_iso_law aα_{Act} aαinv_{Act} := actorlaw_iso_law (actegory_actorlaw Act).
 
-Definition actegory_triangleidentity {C : category} (Act : actegory C) : actegory_triangle_identity au_{Act} aα_{Act} := pr1 (pr22 (actegory_actlaws Act)).
-Definition actegory_pentagonidentity {C : category} (Act : actegory C) : actegory_pentagon_identity aα_{Act} := pr2 (pr22 (actegory_actlaws Act)).
+Lemma actor_nat1 {C : category} (Act : actegory C)
+  {v v' w w' : V} {z z' : C} (f : V⟦v,v'⟧) (g : V⟦w,w'⟧) (h : C⟦z,z'⟧) :
+  (actegory_actordata Act v w z) · ((f ⊗^{Act}_{r} (w ⊗_{Act} z)) · (v' ⊗^{Act}_{l} ((g ⊗^{Act}_{r} z) · (w' ⊗^{Act}_{l} h)))) =
+    (((f ⊗^{Mon_V}_{r} w) · (v' ⊗^{Mon_V}_{l} g))  ⊗^{Act}_{r} z) · ((v' ⊗_{Mon_V} w') ⊗^{Act}_{l} h) · (actegory_actordata Act v' w' z').
+Proof.
+  rewrite assoc.
+  rewrite (actegory_actornatright Act).
+  rewrite assoc'.
+  etrans. {
+    apply cancel_precomposition.
+    rewrite (bifunctor_leftcomp Act).
+    rewrite assoc.
+    rewrite (actegory_actornatleftright Act).
+    apply idpath.
+  }
+
+  etrans. {
+    apply cancel_precomposition.
+    rewrite assoc'.
+    apply cancel_precomposition.
+    apply (actegory_actornatleft Act).
+  }
+  rewrite assoc.
+  rewrite assoc.
+  apply cancel_postcomposition.
+  apply pathsinv0.
+  rewrite (bifunctor_rightcomp Act).
+  apply idpath.
+Qed.
+
+Lemma actor_nat2 {C : category}  (Act : actegory C)
+  {v v' w w' : V} {z z' : C} (f : V⟦v,v'⟧) (g : V⟦w,w'⟧) (h : C⟦z,z'⟧) :
+  (actegory_actordata Act v w z) · (f ⊗^{Act} (g ⊗^{Act} h)) =
+    ((f ⊗^{Mon_V} g) ⊗^{Act} h) · (actegory_actordata Act v' w' z').
+Proof.
+  intros.
+  unfold functoronmorphisms1.
+  exact (actor_nat1 Act f g h).
+Qed.
+
+Definition actegory_triangleidentity {C : category} (Act : actegory C) : actegory_triangle_identity au_{Act} aα_{Act} := pr1 (pr222 (actegory_actlaws Act)).
+Definition actegory_pentagonidentity {C : category} (Act : actegory C) : actegory_pentagon_identity aα_{Act} := pr2 (pr222 (actegory_actlaws Act)).
 
 Lemma isaprop_actegory_laws {C : category} (AD : actegory_data C)
   : isaprop (actegory_laws AD).
@@ -290,9 +300,6 @@ Proof.
   unfold make_is_z_isomorphism.
   unfold pr1.
   apply actor_nat1.
-  - exact (actegory_actornatleft Act).
-  - exact (actegory_actornatright Act).
-  - exact (actegory_actornatleftright Act).
 Qed.
 
 Lemma actorinv_nat2 {C : category} (Act : actegory C)
@@ -345,7 +352,7 @@ Proof.
     apply cancel_postcomposition.
     apply cancel_postcomposition.
     apply cancel_precomposition.
-    apply bifunctor_leftid.
+    apply (bifunctor_leftid Act).
   }
   etrans. {
     apply cancel_postcomposition.
@@ -369,7 +376,7 @@ Proof.
     apply maponpaths.
     apply (pr2 (pr2 (z_iso_from_associator_iso Mon_V w v u))).
   }
-  apply bifunctor_rightid.
+  apply (bifunctor_rightid Act).
 Qed.
 
 End A.
@@ -441,7 +448,7 @@ Section SecondTriangleEquality.
     (α_{Mon_V} I_{Mon_V} I_{Mon_V} v) ⊗^{Act}_{r} x · (I_{ Mon_V} ⊗^{ Mon_V}_{l} lu^{ Mon_V }_{ v}) ⊗^{ Act}_{r} x =
       (ru^{ Mon_V }_{ I_{ Mon_V}} ⊗^{ Mon_V}_{r} v) ⊗^{ Act}_{r} x.
   Proof.
-    refine (! bifunctor_rightcomp _ _ _ _ _ _ _ @ _).
+    refine (! bifunctor_rightcomp Act _ _ _ _ _ _ @ _).
     apply maponpaths.
     apply (monoidal_triangleidentity Mon_V I_{Mon_V} v).
   Qed.
@@ -526,7 +533,7 @@ Section SecondTriangleEquality.
     3: { apply (leftwhiskering_faithful_action(V:=V)). }
     apply pathsinv0.
     refine (right_whisker_with_action_unitor' _ _ @ _).
-    apply bifunctor_leftcomp.
+    apply (bifunctor_leftcomp Act).
   Qed.
 
   Definition actegory_triangleidentity' := right_whisker_with_action_unitor.

--- a/UniMath/CategoryTheory/Actegories/ConstructionOfActegories.v
+++ b/UniMath/CategoryTheory/Actegories/ConstructionOfActegories.v
@@ -36,7 +36,7 @@ Context {V : category} (Mon_V : monoidal V).
 Definition actegory_with_canonical_self_action_data: actegory_data Mon_V V.
 Proof.
   use make_actegory_data.
-  - exact (monoidal_tensor Mon_V).
+  - exact (monoidal_tensor_data Mon_V).
   - exact (lu_{Mon_V}).
   - exact (luinv_{Mon_V}).
   - exact (α_{Mon_V}).
@@ -45,7 +45,8 @@ Defined.
 
 Lemma actegory_with_canonical_self_action_laws: actegory_laws Mon_V actegory_with_canonical_self_action_data.
 Proof.
-  split; [| split; [| split]].
+  split5.
+  - apply monoidal_tensor_is_bifunctor.
   - apply monoidal_leftunitorlaw.
   - apply monoidal_associatorlaw.
   - apply monoidal_triangleidentity.
@@ -70,35 +71,33 @@ Defined.
 
 Lemma lifted_action_data_is_bifunctor: is_bifunctor lifted_action_data.
 Proof.
-  repeat split; red; intros; cbn.
-  - apply bifunctor_leftid.
-  - rewrite functor_id. apply bifunctor_rightid.
-  - apply bifunctor_leftcomp.
-  - rewrite functor_comp. apply bifunctor_rightcomp.
-  - apply bifunctor_equalwhiskers.
+  split5; red; intros; cbn.
+  - apply (bifunctor_leftid Act).
+  - rewrite functor_id. apply (bifunctor_rightid Act).
+  - apply (bifunctor_leftcomp Act).
+  - rewrite functor_comp. apply (bifunctor_rightcomp Act).
+  - apply (bifunctor_equalwhiskers Act).
 Qed.
 
-Definition lifted_action: action(V:=W) C := lifted_action_data,,lifted_action_data_is_bifunctor.
-
-Definition lifted_action_unitor_data : action_unitor_data Mon_W lifted_action.
+Definition lifted_action_unitor_data : action_unitor_data Mon_W lifted_action_data.
 Proof.
   intro x.
   exact (pr1 (fmonoidal_preservesunitstrongly U) ⊗^{Act}_{r} x · au^{Act}_{x}).
 Defined.
 
-Definition lifted_action_unitorinv_data : action_unitorinv_data Mon_W lifted_action.
+Definition lifted_action_unitorinv_data : action_unitorinv_data Mon_W lifted_action_data.
 Proof.
   intro x.
   exact (auinv^{Act}_{x} · fmonoidal_preservesunit U ⊗^{Act}_{r} x).
 Defined.
 
-Definition lifted_actor_data : actor_data Mon_W lifted_action.
+Definition lifted_actor_data : actor_data Mon_W lifted_action_data.
 Proof.
   intros v w x.
   exact (pr1 (fmonoidal_preservestensorstrongly U v w) ⊗^{Act}_{r} x · aα^{Act}_{F v,F w,x}).
 Defined.
 
-Definition lifted_actorinv_data : actorinv_data Mon_W lifted_action.
+Definition lifted_actorinv_data : actorinv_data Mon_W lifted_action_data.
 Proof.
   intros v w x.
   exact (aαinv^{Act}_{F v,F w,x} · fmonoidal_preservestensordata U v w ⊗^{Act}_{r} x).
@@ -107,7 +106,7 @@ Defined.
 Definition lifted_actegory_data: actegory_data Mon_W C.
 Proof.
   use make_actegory_data.
-  - exact lifted_action.
+  - exact lifted_action_data.
   - exact lifted_action_unitor_data.
   - exact lifted_action_unitorinv_data.
   - exact lifted_actor_data.
@@ -116,7 +115,8 @@ Defined.
 
 Lemma lifted_actegory_laws: actegory_laws Mon_W lifted_actegory_data.
 Proof.
-  split4. (* splits into the 4 main goals *)
+  split5. (* splits into the 5 main goals *)
+  - exact lifted_action_data_is_bifunctor.
   - split3.
     + intros x y f. cbn. unfold lifted_action_unitor_data.
       etrans.
@@ -166,7 +166,7 @@ Proof.
       rewrite (actegory_actornatleft Mon_V Act (F v) (F w) z z' h).
       do 2 rewrite assoc.
       apply maponpaths_2.
-      apply bifunctor_equalwhiskers.
+      apply (bifunctor_equalwhiskers Act).
     + intros v v' w z f.
       cbn.
       unfold lifted_actor_data.
@@ -227,7 +227,7 @@ Proof.
     unfold lifted_actor_data.
     unfold lifted_action_unitor_data.
     rewrite assoc'.
-    rewrite bifunctor_leftcomp.
+    rewrite (bifunctor_leftcomp Act).
     etrans. {
       apply maponpaths.
       rewrite assoc.
@@ -235,8 +235,10 @@ Proof.
       apply (actegory_actornatleftright Mon_V Act).
     }
     rewrite assoc'.
-    rewrite (actegory_triangleidentity Mon_V Act (F v) y).
-    do 2 rewrite (! bifunctor_rightcomp _ _ _ _ _ _ _).
+    etrans.
+    { do 2 apply maponpaths.
+      apply (actegory_triangleidentity Mon_V Act (F v) y). }
+    do 2 rewrite (! bifunctor_rightcomp Act _ _ _ _ _ _).
     apply maponpaths.
     rewrite (! fmonoidal_preservesrightunitality U v).
     etrans. {
@@ -276,7 +278,7 @@ Proof.
       exact (actegory_pentagonidentity Mon_V Act (F w) (F v) (F v') z).
     }
 
-    rewrite bifunctor_leftcomp.
+    rewrite (bifunctor_leftcomp Act).
     rewrite assoc'.
     etrans. {
       apply maponpaths.

--- a/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
+++ b/UniMath/CategoryTheory/Actegories/ConstructionOfActegoryMorphisms.v
@@ -196,7 +196,7 @@ Section ActegoryMorphismFromLiftedDistributivity.
       apply maponpaths.
       repeat rewrite assoc.
       apply cancel_postcomposition.
-      apply pathsinv0, bifunctor_equalwhiskers.
+      apply pathsinv0, (bifunctor_equalwhiskers ActV).
     - etrans.
       { repeat rewrite assoc.
         do 2 apply cancel_postcomposition.

--- a/UniMath/CategoryTheory/Actegories/CoproductsInActegories.v
+++ b/UniMath/CategoryTheory/Actegories/CoproductsInActegories.v
@@ -155,13 +155,13 @@ Section BinaryCoproduct.
       apply (z_iso_inv_to_right _ _ _ _ (_,,bincoprod_functor_lineator_strongly δ v _)).
       rewrite assoc'.
       apply (z_iso_inv_to_left _ _ _ (_,,bincoprod_functor_lineator_strongly δ v _)).
-      apply bincoprod_antidistributor_nat_left.
+      apply (bincoprod_antidistributor_nat_left _ _ Act).
     - red.
       intros v1 v2 cd f.
       apply (z_iso_inv_to_right _ _ _ _ (_,,bincoprod_functor_lineator_strongly δ _ _)).
       rewrite assoc'.
       apply (z_iso_inv_to_left _ _ _ (_,,bincoprod_functor_lineator_strongly δ _ _)).
-      apply bincoprod_antidistributor_nat_right.
+      apply (bincoprod_antidistributor_nat_right _ _ Act).
     - red.
       intros v w cd.
       apply pathsinv0, (z_iso_inv_to_right _ _ _ _ (_,,bincoprod_functor_lineator_strongly δ _ _)).

--- a/UniMath/CategoryTheory/Actegories/Examples/ActionOfEndomorphismsInCATElementary.v
+++ b/UniMath/CategoryTheory/Actegories/Examples/ActionOfEndomorphismsInCATElementary.v
@@ -15,7 +15,7 @@ Require Import UniMath.CategoryTheory.BicatOfCatsElementary.
 Require Import UniMath.CategoryTheory.whiskering.
 Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
-Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidal.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidalElementary.
 Require Import UniMath.CategoryTheory.Actegories.Actegories.
 Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
 Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
@@ -62,7 +62,7 @@ Definition action_from_precomp_CAT : bifunctor [C, C] [C, D] [C, D] :=
 
 Definition actegory_from_precomp_CAT_data : actegory_data Mon_endo [C, D].
 Proof.
-  exists action_from_precomp_CAT.
+  exists action_from_precomp_CAT_data.
   split4.
   - intro f. apply lunitor_CAT.
   - intro f. apply linvunitor_CAT.
@@ -72,7 +72,8 @@ Defined.
 
 Lemma actegory_from_precomp_CAT_laws : actegory_laws Mon_endo actegory_from_precomp_CAT_data.
 Proof.
-  split4.
+  split5.
+  - exact action_from_precomp_CAT_laws.
   - split3.
     + intros f g β. apply vcomp_lunitor_CAT.
     + apply lunitor_linvunitor_CAT.

--- a/UniMath/CategoryTheory/Actegories/Examples/SelfActionInCATElementary.v
+++ b/UniMath/CategoryTheory/Actegories/Examples/SelfActionInCATElementary.v
@@ -11,17 +11,17 @@ Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.FunctorCategory.
 Require Import UniMath.CategoryTheory.BicatOfCatsElementary.
 Require Import UniMath.CategoryTheory.whiskering.
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.EndofunctorsWhiskeredMonoidalElementary.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.ActionOfEndomorphismsInCATWhiskeredElementary.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidalElementary.
+Require Import UniMath.CategoryTheory.Actegories.Examples.ActionOfEndomorphismsInCATElementary.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
 
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.CategoryTheory.limits.coproducts.
-Require Import UniMath.CategoryTheory.MonoidalOld.CoproductsInActegories.
+Require Import UniMath.CategoryTheory.Actegories.CoproductsInActegories.
 
 Local Open Scope cat.
 

--- a/UniMath/CategoryTheory/Actegories/MorphismsOfActegories.v
+++ b/UniMath/CategoryTheory/Actegories/MorphismsOfActegories.v
@@ -313,7 +313,7 @@ Arguments lineator_linstrongly {_ _ _ _ _} _ _ _.
     - rewrite id_left. apply id_right.
     - rewrite id_left. apply id_right.
     - rewrite id_right.
-      rewrite bifunctor_leftid.
+      rewrite (bifunctor_leftid Act).
       rewrite id_right.
       apply id_left.
     - apply id_left.
@@ -368,7 +368,7 @@ Section CompositionOfLaxLineators.
       apply lineator_linnatright.
     - assert (auxF := lineator_preservesactor Fl v w x).
       assert (auxG := lineator_preservesactor Gl v w (F x)).
-      rewrite bifunctor_leftcomp.
+      rewrite (bifunctor_leftcomp ActE).
       etrans.
       2: { repeat rewrite assoc. apply cancel_postcomposition.
            repeat rewrite assoc'. do 2 apply maponpaths.
@@ -488,7 +488,7 @@ Section TransformationsOfActegories.
     intros v c.
     rewrite id_right.
     etrans.
-    2: { apply cancel_postcomposition. apply pathsinv0, bifunctor_leftid. }
+    2: { apply cancel_postcomposition. apply pathsinv0, (bifunctor_leftid ActD). }
     apply pathsinv0, id_left.
   Qed.
 
@@ -501,7 +501,7 @@ Section TransformationsOfActegories.
   Proof.
     intros v x.
     cbn.
-    rewrite bifunctor_leftcomp.
+    rewrite (bifunctor_leftcomp ActD).
     rewrite assoc.
     etrans.
     { apply cancel_postcomposition.

--- a/UniMath/CategoryTheory/Actegories/ProductActegory.v
+++ b/UniMath/CategoryTheory/Actegories/ProductActegory.v
@@ -51,23 +51,31 @@ Section OneProduct.
   Proof.
     red; repeat split.
     * intros v cd.
-      apply dirprodeq; apply bifunctor_leftid.
+      apply dirprodeq.
+      - apply (bifunctor_leftid ActC).
+      - apply (bifunctor_leftid ActD).
     * intros cd v.
-      apply dirprodeq; apply bifunctor_rightid.
+      apply dirprodeq.
+      - apply (bifunctor_rightid ActC).
+      - apply (bifunctor_rightid ActD).
     * intros v cd1 cd2 cd3 fg1 fg2.
-      apply dirprodeq; apply bifunctor_leftcomp.
+      apply dirprodeq.
+      - apply (bifunctor_leftcomp ActC).
+      - apply (bifunctor_leftcomp ActD).
     * intros cd v1 v2 v3 h1 h2.
-      apply dirprodeq; apply bifunctor_rightcomp.
+      apply dirprodeq.
+      - apply (bifunctor_rightcomp ActC).
+      - apply (bifunctor_rightcomp ActD).
     * intros v1 v2 cd1 cd2 h fg.
-      apply dirprodeq; apply bifunctor_equalwhiskers.
+      apply dirprodeq.
+      - apply (bifunctor_equalwhiskers ActC).
+      - apply (bifunctor_equalwhiskers ActD).
   Qed.
-
-  Definition actegory_binprod_action : action(V:=V) CD := _,,actegory_binprod_action_data_is_bifunctor.
 
   Definition actegory_binprod_data : actegory_data Mon_V CD.
   Proof.
     use make_actegory_data.
-    - exact actegory_binprod_action.
+    - exact actegory_binprod_action_data.
     - intros cd.
       exact (catbinprodmor (au_{ActC} _) (au_{ActD} _)).
     - intros cd.
@@ -80,17 +88,19 @@ Section OneProduct.
 
   Lemma actegory_binprod_laws : actegory_laws Mon_V actegory_binprod_data.
   Proof.
-    red; repeat split; try red; intros.
-    - apply dirprodeq; apply actegory_unitornat.
-    - apply dirprodeq; apply actegory_unitorisolaw.
-    - apply dirprodeq; apply actegory_unitorisolaw.
-    - apply dirprodeq; apply actegory_actornatleft.
-    - apply dirprodeq; apply actegory_actornatright.
-    - apply dirprodeq; apply actegory_actornatleftright.
-    - apply dirprodeq; apply actegory_actorisolaw.
-    - apply dirprodeq; apply actegory_actorisolaw.
-    - apply dirprodeq; apply actegory_triangleidentity.
-    - apply dirprodeq; apply actegory_pentagonidentity.
+    split.
+    + exact actegory_binprod_action_data_is_bifunctor.
+    + red; repeat split; try red; intros.
+      - apply dirprodeq; apply actegory_unitornat.
+      - apply dirprodeq; apply actegory_unitorisolaw.
+      - apply dirprodeq; apply actegory_unitorisolaw.
+      - apply dirprodeq; apply actegory_actornatleft.
+      - apply dirprodeq; apply actegory_actornatright.
+      - apply dirprodeq; apply actegory_actornatleftright.
+      - apply dirprodeq; apply actegory_actorisolaw.
+      - apply dirprodeq; apply actegory_actorisolaw.
+      - apply dirprodeq; apply actegory_triangleidentity.
+      - apply dirprodeq; apply actegory_pentagonidentity.
   Qed.
 
   Definition actegory_binprod : actegory Mon_V CD := _,,actegory_binprod_laws.
@@ -261,23 +271,21 @@ Definition actegory_prod_action_data : bifunctor_data V PC PC.
   Proof.
     red; repeat split.
     * intros v cs.
-      apply funextsec; intro i; apply bifunctor_leftid.
+      apply funextsec; intro i; apply (bifunctor_leftid (ActC i)).
     * intros cs v.
-      apply funextsec; intro i; apply bifunctor_rightid.
+      apply funextsec; intro i; apply (bifunctor_rightid (ActC i)).
     * intros v cs1 cs2 cs3 fs1 fs2.
-      apply funextsec; intro i; apply bifunctor_leftcomp.
+      apply funextsec; intro i; apply (bifunctor_leftcomp (ActC i)).
     * intros cs v1 v2 v3 h1 h2.
-      apply funextsec; intro i; apply bifunctor_rightcomp.
+      apply funextsec; intro i; apply (bifunctor_rightcomp (ActC i)).
     * intros v1 v2 cs1 cs2 h fs.
-      apply funextsec; intro i; apply bifunctor_equalwhiskers.
+      apply funextsec; intro i; apply (bifunctor_equalwhiskers (ActC i)).
   Qed.
-
-  Definition actegory_prod_action : action(V:=V) PC := _,,actegory_prod_action_data_is_bifunctor.
 
   Definition actegory_prod_data : actegory_data Mon_V PC.
   Proof.
     use make_actegory_data.
-    - exact actegory_prod_action.
+    - exact actegory_prod_action_data.
     - intros cs.
       intro i. apply au_{ActC i}.
     - intros cs.
@@ -290,17 +298,19 @@ Definition actegory_prod_action_data : bifunctor_data V PC PC.
 
   Lemma actegory_prod_laws : actegory_laws Mon_V actegory_prod_data.
   Proof.
-    red; repeat split; try red; intros; apply funextsec; intro i.
-    - apply actegory_unitornat.
-    - apply actegory_unitorisolaw.
-    - apply actegory_unitorisolaw.
-    - apply actegory_actornatleft.
-    - apply actegory_actornatright.
-    - apply actegory_actornatleftright.
-    - apply actegory_actorisolaw.
-    - apply actegory_actorisolaw.
-    - apply actegory_triangleidentity.
-    - apply actegory_pentagonidentity.
+    split.
+    + exact actegory_prod_action_data_is_bifunctor.
+    + red; repeat split; try red; intros; apply funextsec; intro i.
+      - apply actegory_unitornat.
+      - apply actegory_unitorisolaw.
+      - apply actegory_unitorisolaw.
+      - apply actegory_actornatleft.
+      - apply actegory_actornatright.
+      - apply actegory_actornatleftright.
+      - apply actegory_actorisolaw.
+      - apply actegory_actorisolaw.
+      - apply actegory_triangleidentity.
+      - apply actegory_pentagonidentity.
   Qed.
 
   Definition actegory_prod : actegory Mon_V PC := _,,actegory_prod_laws.

--- a/UniMath/CategoryTheory/Actegories/ProductsInActegories.v
+++ b/UniMath/CategoryTheory/Actegories/ProductsInActegories.v
@@ -79,10 +79,10 @@ Section BinaryProduct.
       2: { apply pathsinv0, postcompWithBinProductArrow. }
       apply maponpaths_12.
       + etrans.
-        { apply bifunctor_equalwhiskers. }
+        { apply (bifunctor_equalwhiskers Act). }
         apply idpath.
       + etrans.
-        { apply bifunctor_equalwhiskers. }
+        { apply (bifunctor_equalwhiskers Act). }
         apply idpath.
     - red.
       intros v w cd.

--- a/UniMath/CategoryTheory/Monoidal/Displayed/TotalDisplayedMonoidal.v
+++ b/UniMath/CategoryTheory/Monoidal/Displayed/TotalDisplayedMonoidal.v
@@ -152,7 +152,7 @@ Section MonoidalTotalCategory.
         ,, total_rightcompax DT
         ,, total_functoronmorphisms_are_equal DT).
 
-  Local Notation Tt := total_tensor.
+  Local Notation Tt := total_tensor_data.
 
   Definition total_unit
              {C : category}
@@ -263,7 +263,7 @@ Section MonoidalTotalCategory.
     : monoidal_data T(D).
   Proof.
     use make_monoidal_data.
-    - exact (total_tensor DM).
+    - exact (total_tensor_data DM).
     - exact (total_unit DM dI_{DM}).
     - exact (total_leftunitordata dlu^{DM}).
     - exact (total_leftunitorinvdata dluinv^{DM}).

--- a/UniMath/CategoryTheory/Monoidal/Examples/EndofunctorsMonoidalElementary.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/EndofunctorsMonoidalElementary.v
@@ -17,11 +17,11 @@ Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalFunctors.
 
-Import MonoidalNotations.
-
 Local Open Scope cat.
 
 Section FixACategory.
+
+  Import MonoidalNotations.
 
   Context (C : category).
 
@@ -107,4 +107,5 @@ Section FixACategory.
     exists monendocat_triangle_identity.
     exact monendocat_pentagon_identity.
   Defined.
+
 End FixACategory.

--- a/UniMath/CategoryTheory/Monoidal/Examples/MonadsAsMonoidsElementary.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/MonadsAsMonoidsElementary.v
@@ -17,7 +17,7 @@ Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
 Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
 
 Require Import UniMath.CategoryTheory.Monoidal.CategoriesOfMonoids.
-Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidal.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidalElementary.
 Require Import UniMath.CategoryTheory.Monads.Monads.
 
 Local Open Scope cat.

--- a/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalCategories.v
@@ -878,7 +878,7 @@ Section OppositeMonoidal.
 
   Definition monoidal_opp_data : monoidal_data C^op.
   Proof.
-    exists monoidal_opp_tensor.
+    exists monoidal_opp_tensor_data.
     exists I_{M}.
     exists luinv_{M}.
     exists lu_{M}.

--- a/UniMath/SubstitutionSystems/ActionScenarioForGenMendlerIteration_alt.v
+++ b/UniMath/SubstitutionSystems/ActionScenarioForGenMendlerIteration_alt.v
@@ -16,11 +16,11 @@ Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.CategoryTheory.Chains.Chains.
 Require Import UniMath.CategoryTheory.Chains.Adamek.
 Require Import UniMath.CategoryTheory.Chains.OmegaCocontFunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.CoproductsInActegories.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.CoproductsInActegories.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
 Require Import UniMath.SubstitutionSystems.GenMendlerIteration_alt.
 Require Import UniMath.SubstitutionSystems.GeneralizedSubstitutionSystems.

--- a/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
+++ b/UniMath/SubstitutionSystems/BindingSigToMonad_actegorical.v
@@ -35,17 +35,17 @@ Require Import UniMath.CategoryTheory.categories.HSET.Limits.
 Require Import UniMath.CategoryTheory.categories.HSET.Colimits.
 Require Import UniMath.CategoryTheory.categories.HSET.Structures.
 
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegoryMorphisms.
-Require Import UniMath.CategoryTheory.MonoidalOld.CoproductsInActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.CategoriesOfMonoidsWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.MonoidalPointedObjects.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.EndofunctorsWhiskeredMonoidalElementary.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.MonadsAsMonoidsWhiskeredElementary.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegoryMorphisms.
+Require Import UniMath.CategoryTheory.Actegories.CoproductsInActegories.
+Require Import UniMath.CategoryTheory.Monoidal.CategoriesOfMonoids.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonoidalPointedObjects.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidalElementary.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonadsAsMonoidsElementary.
 
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
 

--- a/UniMath/SubstitutionSystems/ConstructionOfGHSS.v
+++ b/UniMath/SubstitutionSystems/ConstructionOfGHSS.v
@@ -27,15 +27,14 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
 
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.CategoriesOfMonoidsWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.CoproductsInActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.MonoidalPointedObjects.
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Monoidal.CategoriesOfMonoids.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.CoproductsInActegories.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonoidalPointedObjects.
 
 Require Import UniMath.SubstitutionSystems.GeneralizedSubstitutionSystems.
 Require Import UniMath.SubstitutionSystems.ActionScenarioForGenMendlerIteration_alt.
@@ -415,14 +414,14 @@ Section InitialAlgebraToGHSS.
                   apply (pr12 Hμη). }
              repeat rewrite assoc.
              apply cancel_postcomposition.
-             rewrite bifunctor_equalwhiskers.
+             rewrite (bifunctor_equalwhiskers Mon_V).
              unfold functoronmorphisms2.
              rewrite assoc.
              etrans.
              { apply cancel_postcomposition.
                apply pathsinv0, (functor_comp (leftwhiskering_functor Mon_V t)). }
              rewrite auxη.
-             apply pathsinv0, bifunctor_equalwhiskers.
+             apply pathsinv0, (bifunctor_equalwhiskers Mon_V).
           -- change (t ⊗^{Mon_V}_{l} τ · (h ⊗^{ Mon_V} h · aμ) = θ (t,, η) t · # H (h ⊗^{ Mon_V} h · aμ) · aτ).
              etrans.
              2: { apply cancel_postcomposition.
@@ -450,12 +449,12 @@ Section InitialAlgebraToGHSS.
                   apply (functor_comp (leftwhiskering_functor Mon_V av)). }
              rewrite <- auxτ.
              etrans.
-             { rewrite bifunctor_equalwhiskers.
+             { rewrite (bifunctor_equalwhiskers Mon_V).
                unfold functoronmorphisms2.
                rewrite assoc.
                apply cancel_postcomposition.
                apply pathsinv0, (functor_comp (leftwhiskering_functor Mon_V t)). }
-             apply pathsinv0, bifunctor_equalwhiskers.
+             apply pathsinv0, (bifunctor_equalwhiskers Mon_V).
         * apply pathsinv0, path_to_ctr.
           red; split.
           -- change (t ⊗^{Mon_V}_{l} η · (μ · h) = ru^{ Mon_V }_{ t} · h).

--- a/UniMath/SubstitutionSystems/EquivalenceLaxLineatorsHomogeneousCase.v
+++ b/UniMath/SubstitutionSystems/EquivalenceLaxLineatorsHomogeneousCase.v
@@ -13,14 +13,14 @@ Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.FunctorCategory.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.EndofunctorsWhiskeredMonoidalElementary.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.ActionOfEndomorphismsInCATWhiskeredElementary.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegories.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.EndofunctorsMonoidalElementary.
+Require Import UniMath.CategoryTheory.Actegories.Examples.ActionOfEndomorphismsInCATElementary.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
 Require Import UniMath.CategoryTheory.coslicecat.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.MonoidalPointedObjects.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonoidalPointedObjects.
 (* Require Import UniMath.SubstitutionSystems.EquivalenceSignaturesWithActegoryMorphisms. *)
 
 Import MonoidalNotations.

--- a/UniMath/SubstitutionSystems/GeneralizedSubstitutionSystems.v
+++ b/UniMath/SubstitutionSystems/GeneralizedSubstitutionSystems.v
@@ -9,16 +9,16 @@ Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Isos.
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.CategoriesOfMonoidsWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.CoproductsInActegories.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Monoidal.CategoriesOfMonoids.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.CoproductsInActegories.
 Require Import UniMath.CategoryTheory.coslicecat.
 Require Import UniMath.CategoryTheory.limits.bincoproducts.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.MonoidalPointedObjects.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonoidalPointedObjects.
 
 
 Local Open Scope cat.
@@ -249,7 +249,7 @@ Section hss.
     - etrans.
       2: { rewrite assoc.
            apply cancel_postcomposition.
-           apply bifunctor_equalwhiskers. }
+           apply (bifunctor_equalwhiskers Mon_V). }
       unfold functoronmorphisms1.
       etrans.
       2: { rewrite assoc'.
@@ -335,7 +335,7 @@ Section hss.
     rewrite assoc.
     etrans.
     2: { apply cancel_postcomposition.
-         apply bifunctor_equalwhiskers. }
+         apply (bifunctor_equalwhiskers Mon_V). }
     unfold functoronmorphisms1.
     rewrite assoc'.
     etrans.
@@ -376,8 +376,8 @@ Section hss.
       repeat rewrite assoc.
       apply cancel_postcomposition.
       cbn.
-      apply bifunctor_equalwhiskers.
-  Time Qed. (* slow *)
+      apply (bifunctor_equalwhiskers Mon_V).
+  Qed.
 
   Definition gh_squared : PtdV := Ptd_from_ghss ⊗_{Mon_PtdV} Ptd_from_ghss.
 
@@ -393,7 +393,7 @@ Section hss.
     2: { apply pathsinv0, ghss_second_monoidlaw_aux. }
     rewrite assoc.
     apply cancel_postcomposition.
-    apply bifunctor_equalwhiskers.
+    apply (bifunctor_equalwhiskers Mon_V).
   Qed.
 
   Definition μ_2_Ptd : gh_squared --> Ptd_from_ghss := μ_2,,μ_2_is_Ptd_mor.
@@ -408,7 +408,7 @@ Section hss.
                      (actegory_with_canonical_pointed_action Mon_V)
                      (actegory_with_canonical_pointed_action Mon_V)
                      H θ gh_squared Ptd_from_ghss gh μ_2_Ptd).
-    simpl in aux. (* simpl not cbn *)
+    simpl in aux. (* simpl not cbn for efficiency of Qed *)
     etrans.
     { exact aux. }
     apply idpath.
@@ -425,7 +425,7 @@ Section hss.
         etrans.
         2: { rewrite assoc.
              apply cancel_postcomposition.
-             apply bifunctor_equalwhiskers. }
+             apply (bifunctor_equalwhiskers Mon_V). }
         unfold functoronmorphisms1.
         etrans.
         2: { rewrite assoc'.
@@ -449,7 +449,7 @@ Section hss.
         do 2 rewrite assoc.
         apply cancel_postcomposition.
         cbn.
-        apply bifunctor_equalwhiskers.
+        apply (bifunctor_equalwhiskers Mon_V).
     - (** this case is the monoidal generalization of the first item on p.168 of Matthes & Uustalu, TCS 2004 *)
       apply pathsinv0, (gfbracket_unique(Z:=gh_squared)).
       split.
@@ -461,7 +461,7 @@ Section hss.
              rewrite <- monoidal_associatornatleft.
              rewrite assoc'.
              apply maponpaths.
-             apply bifunctor_leftcomp. }
+             apply (bifunctor_leftcomp Mon_V). }
         etrans.
         2: { apply cancel_postcomposition.
              do 2 apply maponpaths.
@@ -499,13 +499,13 @@ Section hss.
         etrans.
         { repeat rewrite assoc'.
           apply maponpaths.
-          do 2 rewrite <- bifunctor_leftcomp.
+          do 2 rewrite <- (bifunctor_leftcomp Mon_V).
           apply maponpaths.
           rewrite assoc.
           apply (gfbracket_τ(Z:=Ptd_from_ghss)).
         }
         cbn.
-        rewrite bifunctor_leftcomp.
+        rewrite (bifunctor_leftcomp Mon_V).
         repeat rewrite assoc.
         apply cancel_postcomposition.
         apply monoidal_associatornatleft.

--- a/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
+++ b/UniMath/SubstitutionSystems/MultiSorted_actegorical.v
@@ -52,15 +52,15 @@ Require Import UniMath.SubstitutionSystems.SignatureExamples.
 
 
 (** for the additions in 2023 *)
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.Actegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.CoproductsInActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.ConstructionOfActegoryMorphisms.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.MonoidalPointedObjects.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.ActionOfEndomorphismsInCATWhiskeredElementary.
-Require Import UniMath.CategoryTheory.MonoidalOld.Examples.SelfActionInCATWhiskeredElementary.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Actegories.Actegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Actegories.CoproductsInActegories.
+Require Import UniMath.CategoryTheory.Actegories.ConstructionOfActegoryMorphisms.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.MonoidalPointedObjects.
+Require Import UniMath.CategoryTheory.Actegories.Examples.ActionOfEndomorphismsInCATElementary.
+Require Import UniMath.CategoryTheory.Actegories.Examples.SelfActionInCATElementary.
 (* Require Import UniMath.SubstitutionSystems.EquivalenceSignaturesWithActegoryMorphisms. *)
 Require Import UniMath.SubstitutionSystems.EquivalenceLaxLineatorsHomogeneousCase.
 Require Import UniMath.SubstitutionSystems.MultiSorted_alt.

--- a/UniMath/SubstitutionSystems/SigmaMonoids.v
+++ b/UniMath/SubstitutionSystems/SigmaMonoids.v
@@ -12,10 +12,10 @@ Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.DisplayedCats.Total.
-Require Import UniMath.CategoryTheory.MonoidalOld.WhiskeredBifunctors.
-Require Import UniMath.CategoryTheory.MonoidalOld.MonoidalCategoriesWhiskered.
-Require Import UniMath.CategoryTheory.MonoidalOld.MorphismsOfActegories.
-Require Import UniMath.CategoryTheory.MonoidalOld.CategoriesOfMonoidsWhiskered.
+Require Import UniMath.CategoryTheory.Monoidal.WhiskeredBifunctors.
+Require Import UniMath.CategoryTheory.Monoidal.MonoidalCategories.
+Require Import UniMath.CategoryTheory.Actegories.MorphismsOfActegories.
+Require Import UniMath.CategoryTheory.Monoidal.CategoriesOfMonoids.
 Require Import UniMath.CategoryTheory.FunctorAlgebras.
 Require Import UniMath.SubstitutionSystems.GeneralizedSubstitutionSystems.
 

--- a/UniMath/SubstitutionSystems/Signatures.v
+++ b/UniMath/SubstitutionSystems/Signatures.v
@@ -39,9 +39,11 @@ Require Import UniMath.SubstitutionSystems.Notation.
 
 
 (** only needed for Section [homogeneous_case]: *)
+(* TODO RM
 Require Import UniMath.Bicategories.MonoidalCategories.ActionBasedStrength.
 Require Import UniMath.Bicategories.MonoidalCategories.EndofunctorsMonoidal.
 Require Import UniMath.Bicategories.MonoidalCategories.PointedFunctorsMonoidal.
+*)
 
 
 Local Open Scope subsys.
@@ -509,6 +511,7 @@ Proof.
   apply functor_id.
 Qed.
 
+(* TODO RM
 Local Definition ptd := monoidal_cat_of_pointedfunctors C.
 Local Definition endo := monoidal_cat_of_endofunctors C.
 Local Definition forget := forgetful_functor_from_ptd_as_strong_monoidal_functor C.
@@ -650,7 +653,7 @@ Section strength_in_signature_is_a_relative_strength.
   Definition rel_strength_from_signature : rel_strength forget H := (ϛ',,rel_strength_from_signature_laws).
 
 End strength_in_signature_is_a_relative_strength.
-
+*)
 End homogeneous_case.
 
 Arguments PrestrengthForSignature {_ _ _} _ .


### PR DESCRIPTION
the files in SubstitutionSystems in this commit now work with the newly organized material (no longer with MonoidalOld)

But I cheated on Signatures.v by commenting out ~150loc.
My overall impression: the transition goes rather smoothly