### PR TITLE
lift_strict_and_monotone_map does not need points in the ingredients

### DIFF
--- a/UniMath/CategoryTheory/Monoidal/Examples/LiftPoset.v
+++ b/UniMath/CategoryTheory/Monoidal/Examples/LiftPoset.v
@@ -47,7 +47,7 @@ Definition lift_poset_functor_data
 Proof.
   use make_functor_data.
   - exact (λ X, _ ,, lift_pointed_PartialOrder (pr12 X)).
-  - exact (λ X Y f, _ ,, lift_strict_and_monotone_map (pr2 f)).
+  - exact (λ X Y f, _ ,, lift_strict_and_monotone_map (pr12 f)).
 Defined.
 
 Proposition lift_poset_functor_laws

--- a/UniMath/OrderTheory/Posets/LiftPoset.v
+++ b/UniMath/OrderTheory/Posets/LiftPoset.v
@@ -88,9 +88,9 @@ Defined.
 Proposition lift_strict_and_monotone_map
             {X Y : hSet}
             {f : X → Y}
-            {PX : pointed_PartialOrder X}
-            {PY : pointed_PartialOrder Y}
-            (Pf : is_strict_and_monotone PX PY f)
+            {PX : PartialOrder X}
+            {PY : PartialOrder Y}
+            (Pf : is_monotone PX PY f)
   : is_strict_and_monotone
       (lift_pointed_PartialOrder PX)
       (lift_pointed_PartialOrder PY)


### PR DESCRIPTION
I wonder if `lift_poset_comonad` could not even be a relative comonad for a lift functor from the partial orders to the pointed partial orders.  But we do not have relative comonads in UniMath, and the style with comultiplication is not available in relative comonads. Anyway, the symmetric monoidal structure is then driving the development. But still, could `lift_poset_comonad` not be expressed for a simpler description of the underlying category of `pointed_poset_sym_mon_closed_cat`?